### PR TITLE
Modify dbmigrate task name to match the keyvault name

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -10,5 +10,5 @@ def component = "web"
 // 1. https://github.com/hmcts/cnp-jenkins-library
 // 2. https://hmcts.github.io/ways-of-working/common-pipeline/common-pipeline.html#common-pipeline
 withPipeline(type, product, component) {
-  enableDbMigration("lgyiac")
+  enableDbMigration("lgy-iac")
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-4467

### Change description ###

Modify dbmigrate task name to match the keyvault name lgy-iac (not lgyiac)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
