### PR TITLE
The migrationtask uses the component name (web) as the prefix for the…

### DIFF
--- a/charts/lgy-iac-web/Chart.yaml
+++ b/charts/lgy-iac-web/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for lgy-iac-web App
 name: lgy-iac-web
 home: https://github.com/hmcts/lgy-iac-web
-version: 0.0.6
+version: 0.0.7
 maintainers:
   - name: DTS Legacy Apps team
 dependencies:

--- a/charts/lgy-iac-web/values.yaml
+++ b/charts/lgy-iac-web/values.yaml
@@ -7,13 +7,13 @@ java:
     lgy-iac:
       resourceGroup: lgy-iac-{{ .Values.global.environment }}
       secrets:
-        - name: lgy-iac-POSTGRES-DATABASE
+        - name: web-POSTGRES-DATABASE
           alias: POSTGRES_DATABASE
-        - name: lgy-iac-POSTGRES-HOST
+        - name: web-POSTGRES-HOST
           alias: POSTGRES_HOST
-        - name: lgy-iac-POSTGRES-USER
+        - name: web-POSTGRES-USER
           alias: POSTGRES_USER
-        - name: lgy-iac-POSTGRES-PASS
+        - name: web-POSTGRES-PASS
           alias: POSTGRES_PASSWORD
   environment:
     POSTGRES_SSL_MODE: require

--- a/infrastructure/db-postgres.tf
+++ b/infrastructure/db-postgres.tf
@@ -5,31 +5,31 @@ data "azurerm_subnet" "postgres" {
 }
 
 resource "azurerm_key_vault_secret" "postgres-user" {
-  name         = "lgy-iac-POSTGRES-USER"
+  name         = "web-POSTGRES-USER"
   value        = module.database.user_name
   key_vault_id = module.vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "postgres-password" {
-  name         = "lgy-iac-POSTGRES-PASS"
+  name         = "web-POSTGRES-PASS"
   value        = module.database.postgresql_password
   key_vault_id = module.vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "postgres-host" {
-  name         = "lgy-iac-POSTGRES-HOST"
+  name         = "web-POSTGRES-HOST"
   value        = module.database.host_name
   key_vault_id = module.vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "postgres-port" {
-  name         = "lgy-iac-POSTGRES-PORT"
+  name         = "web-POSTGRES-PORT"
   value        = module.database.postgresql_listen_port
   key_vault_id = module.vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "postgres-database" {
-  name         = "lgy-iac-POSTGRES-DATABASE"
+  name         = "web-POSTGRES-DATABASE"
   value        = module.database.postgresql_database
   key_vault_id = module.vault.key_vault_id
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-4467

### Change description ###

The migrationtask uses the component name (web) as the prefix for the flyway database secrets

**Does this PR introduce a breaking change?** (check one with "x")

[ ] Yes
[x] No
```
